### PR TITLE
Remove references to Stripe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install -r requirements.txt
   - python setup.py clean --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
 install:
   - pip install -r requirements.txt
   - python setup.py clean --all

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,3 +22,5 @@
   - Add Accept endpoint
 2.3.0- November, 2017
   - Add support for overriding version
+2.3.1- September, 2018
+  - Update docs

--- a/chargehound/resources.py
+++ b/chargehound/resources.py
@@ -48,7 +48,8 @@ class Disputes(object):
 
     """
     A list of disputes
-    This method will list all the disputes that we have synced from Stripe.
+    This method will list all the disputes that we have synced from
+    your payment processor.
     By default the disputes will be ordered by `created`
     with the most recent dispute first.
     `has_more` will be `true` if more results are available.
@@ -64,9 +65,9 @@ class Disputes(object):
     """
     Submitting a dispute
     You will want to submit the dispute through Chargehound after you recieve
-    a notification from Stripe of a new dispute.
+    a webhook notification of a new dispute.
     With one `POST` request you can update a dispute with the
-    evidence fields and send the generated response to Stripe.
+    evidence fields and submit generated response.
     The response will have a `201` status if the submit was successful.
     The dispute will also be in the submitted state.
 

--- a/chargehound/version.py
+++ b/chargehound/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = '2.3.0'
+VERSION = '2.3.1'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ a new version.""")
 
 setup(
     name='chargehound',
-    version='2.3.0',
+    version='2.3.1',
     author='Chargehound',
     author_email='support@chargehound.com',
     packages=['chargehound'],


### PR DESCRIPTION
Because we support many other payment processors now.